### PR TITLE
Demo page now references react and react-dom

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ structure as the [`init/demo`](./init/demo) directory in this archetype, you can
 start up a demo development server:
 
 ```sh
-$ builder run demo
+$ npm run demo
 $ open http://localhost:9000
 ```
 

--- a/init/demo/index.html
+++ b/init/demo/index.html
@@ -1,11 +1,12 @@
 <!DOCTYPE html>
 <html>
-    <head>
-        <meta charset="UTF-8" />
-    </head>
-    <body>
-        <div id="react-demo-entry-point"></div>
-    </body>
-
-    <script type="text/javascript" src="/build/bundle.js"></script>
+<head>
+    <meta charset="UTF-8" />
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/react/15.6.1/react.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/react/15.6.1/react-dom.min.js"></script>
+</head>
+<body>
+    <div id="react-demo-entry-point"></div>
+    <script type="text/javascript" src="/lib/bundle.js"></script>
+</body>
 </html>


### PR DESCRIPTION
Fixes #27 

`demo/index.html` now:
1. References `/lib/bundle.js` instead of `/build/bundle.js`, this is how `webpack` is configured for dev outputs
2. References react and react-dom from CDN, this dependencies are configured as externals in webpack.