### PR TITLE
Fix hot loading

### DIFF
--- a/init/demo/index.html
+++ b/init/demo/index.html
@@ -2,12 +2,12 @@
 <html>
     <head>
         <meta charset="UTF-8" />
+        <script type="text/javascript" src="https://unpkg.com/react@15.4.2/dist/react.min.js"></script>
+        <script type="text/javascript" src="https://unpkg.com/react-dom@15.4.2/dist/react-dom.min.js"></script>
     </head>
     <body>
         <div id="react-demo-entry-point"></div>
     </body>
 
-    <script type="text/javascript" src="https://unpkg.com/react@15.4.2/dist/react.min.js"></script>
-    <script type="text/javascript" src="https://unpkg.com/react-dom@15.4.2/dist/react-dom.min.js"></script>
     <script type="text/javascript" src="/build/bundle.js"></script>
 </html>

--- a/init/demo/index.html
+++ b/init/demo/index.html
@@ -7,5 +7,7 @@
         <div id="react-demo-entry-point"></div>
     </body>
 
+    <script type="text/javascript" src="https://unpkg.com/react@15.4.2/dist/react.min.js"></script>
+    <script type="text/javascript" src="https://unpkg.com/react-dom@15.4.2/dist/react-dom.min.js"></script>
     <script type="text/javascript" src="/build/bundle.js"></script>
 </html>

--- a/init/demo/index.js
+++ b/init/demo/index.js
@@ -3,7 +3,16 @@ import ReactDOM from 'react-dom';
 
 import Demo from './Demo.react';
 
-ReactDOM.render(
+// Fix for rendering React externally:
+// See https://github.com/gaearon/react-hot-loader/tree/v1.3.1/docs#usage-with-external-react
+const rootInstance = ReactDOM.render(
     <Demo/>,
     document.getElementById('react-demo-entry-point')
 );
+
+require('react-hot-loader/Injection').RootInstanceProvider.injectProvider({
+    getRootInstances: function () {
+      // Help React Hot Loader figure out the root component instances on the page:
+      return [rootInstance];
+    }
+});


### PR DESCRIPTION
Fix includes external react suggestion from https://github.com/plotly/dash-components-archetype/pull/28/files and suggestions from https://github.com/gaearon/react-hot-loader/tree/v1.3.1/docs#usage-with-external-react

It works now
![hot loading](https://user-images.githubusercontent.com/1280389/29046020-b0ff7c12-7b93-11e7-9947-2721e3dcdac8.gif)
