### PR TITLE
Component dist bundle should be hosted on git

### DIFF
--- a/init/{{gitignore}}
+++ b/init/{{gitignore}}
@@ -5,7 +5,6 @@ lib/
 lib/bundle.js*
 node_modules/
 <%= packageNameUnderscored %>/metadata.json
-<%= packageNameUnderscored %>/bundle.js*
 .npm
 vv/
 venv/


### PR DESCRIPTION
Related to https://github.com/plotly/dash-core-components/issues/92