### PR TITLE
add python build folders to npmignore

### DIFF
--- a/init/{{npmignore}}
+++ b/init/{{npmignore}}
@@ -6,4 +6,5 @@ venv/
 *.pyc
 *.log
 .DS_Store
-
+dist/
+build/


### PR DESCRIPTION
the python command for creating a package is:
```
python setup.py sdist
```
this adds the package in a `dist/` folder. `.npmignore` blacklists folders and so this `dist/` folder was getting uploaded to npm, containing all of the previous tarballs of the package. in the case of dash-core-components, this turned out to be hundreds of megabytes (!!)