### PR TITLE
check that Dash was imported correctly and sys.exit(1) if failed

### DIFF
--- a/init/{{packageNameUnderscored}}/__init__.py
+++ b/init/{{packageNameUnderscored}}/__init__.py
@@ -1,7 +1,16 @@
+from __future__ import print_function as _
+
 import os as _os
-import dash as _dash
 import sys as _sys
+
+import dash as _dash
+
 from .version import __version__
+
+if not hasattr(_dash, 'development'):
+    print("Dash was not successfully imported. Make sure you don't have a file "
+          "named \n'dash.py' in your current directory.", file=_sys.stderr)
+    _sys.exit(1)
 
 _current_path = _os.path.dirname(_os.path.abspath(__file__))
 


### PR DESCRIPTION
This provides more helpful feedback when a user has a file dash.py in the current directory, which shadows  the dash package itself. After printing a more helpful message than the previous exception they would have faced, the program now exits. 