### PR TITLE
Corrected LICENSE filename in MANIFEST.in

### DIFF
--- a/init/MANIFEST.in
+++ b/init/MANIFEST.in
@@ -2,4 +2,4 @@ include <%= packageNameUnderscored %>/bundle.js
 include <%= packageNameUnderscored %>/bundle.js.map
 include <%= packageNameUnderscored %>/metadata.json
 include README.md
-include LICENSE.md
+include LICENSE.txt


### PR DESCRIPTION
Replaced LICENSE.md by LICENSE.txt in MANIFEST.in since the [builder init](https://github.com/plotly/dash-components-archetype/blob/master/init/) creates the latter.