### PR TITLE
Generate Dash components at buildtime rather than runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.3.0] - 2018-07-11
+### Changed
+- a `generate-python-classes` build step is added to build scripts in `package.json`.
+- Components are now imported from .py class files in the `packageNameUnderscored` directory. 
+
 ## [0.2.11] - 2017-08-08
 ### Fixed
 - Fix src location of demo HTML page

--- a/dev/package.json
+++ b/dev/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash-components-archetype-dev",
-  "version": "0.2.11",
+  "version": "0.3.0",
   "description": "A [Builder](https://github.com/FormidableLabs/builder) Archetype for Dash components suites (Development)",
   "main": "index.js",
   "dependencies": {

--- a/init/package.json
+++ b/init/package.json
@@ -14,6 +14,7 @@
   "homepage": "https://github.com/<%= packageGitHubOrg %>/<%= packageName %>",<% } %>
   "scripts": {
     "copy-lib": "copyfiles -u 1 lib/* <%= packageNameUnderscored %>",
+    "generate-python-classes": "python -c 'import dash; dash.development.component_loader.generate_classes(\"<%= packageNameUnderscored %>\")'",
     "demo": "builder run demo",
     "install-local": "npm run copy-lib && python setup.py install",
     "prepublish": "npm test && builder run build-dist && npm run copy-lib",

--- a/init/{{packageNameUnderscored}}/__init__.py
+++ b/init/{{packageNameUnderscored}}/__init__.py
@@ -2,11 +2,10 @@ from __future__ import print_function as _
 
 import os as _os
 import sys as _sys
-import glob as _glob
-from importlib import import_module as _import
-
 import dash as _dash
 
+from ._imports_ import *
+from ._imports_ import __all__
 from .version import __version__
 
 
@@ -15,22 +14,9 @@ if not hasattr(_dash, 'development'):
           "named \n'dash.py' in your current directory.", file=_sys.stderr)
     _sys.exit(1)
 
+
 _current_path = _os.path.dirname(_os.path.abspath(__file__))
 
-_component_files = map(
-    lambda x: _os.path.splitext(_os.path.basename(x))[0],
-    filter(
-        lambda x: _os.path.basename(x) not in ['__init__.py', 'version.py'],
-        _glob.glob(_os.path.join(_current_path, '*.py'))
-    )
-)
-
-_components = [
-    getattr(
-        _import(".{:s}".format(c), package='<%= packageNameUnderscored %>'),
-        c
-    ) for c in _component_files
-]
 
 _this_module = _sys.modules[__name__]
 
@@ -49,7 +35,6 @@ _js_dist = [
 _css_dist = []
 
 
-for _component in _components:
-    setattr(_this_module, _component.__name__, _component)
-    setattr(_component, '_js_dist', _js_dist)
-    setattr(_component, '_css_dist', _css_dist)
+for _component in __all__:
+    setattr(locals()[_component], '_js_dist', _js_dist)
+    setattr(locals()[_component], '_css_dist', _css_dist)

--- a/init/{{packageNameUnderscored}}/__init__.py
+++ b/init/{{packageNameUnderscored}}/__init__.py
@@ -2,10 +2,13 @@ from __future__ import print_function as _
 
 import os as _os
 import sys as _sys
+import glob as _glob
+from importlib import import_module as _import
 
 import dash as _dash
 
 from .version import __version__
+
 
 if not hasattr(_dash, 'development'):
     print("Dash was not successfully imported. Make sure you don't have a file "
@@ -14,10 +17,20 @@ if not hasattr(_dash, 'development'):
 
 _current_path = _os.path.dirname(_os.path.abspath(__file__))
 
-_components = _dash.development.component_loader.load_components(
-    _os.path.join(_current_path, 'metadata.json'),
-    '<%= packageNameUnderscored %>'
+_component_files = map(
+    lambda x: _os.path.splitext(_os.path.basename(x))[0],
+    filter(
+        lambda x: _os.path.basename(x) not in ['__init__.py', 'version.py'],
+        _glob.glob(_os.path.join(_current_path, '*.py'))
+    )
 )
+
+_components = [
+    getattr(
+        _import(".{:s}".format(c), package='<%= packageNameUnderscored %>'),
+        c
+    ) for c in _component_files
+]
 
 _this_module = _sys.modules[__name__]
 

--- a/init/{{packageNameUnderscored}}/__init__.py
+++ b/init/{{packageNameUnderscored}}/__init__.py
@@ -4,15 +4,17 @@ import os as _os
 import sys as _sys
 import dash as _dash
 
-from ._imports_ import *
-from ._imports_ import __all__
 from .version import __version__
 
-
+# Module imports trigger a dash.development import, need to check this first
 if not hasattr(_dash, 'development'):
     print("Dash was not successfully imported. Make sure you don't have a file "
           "named \n'dash.py' in your current directory.", file=_sys.stderr)
     _sys.exit(1)
+
+
+from ._imports_ import *
+from ._imports_ import __all__
 
 
 _current_path = _os.path.dirname(_os.path.abspath(__file__))

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "clean-lib": "mkdirp lib && rimraf lib/*",
     "demo": "webpack-dev-server --hot --inline --port=9000 --content-base demo --config=node_modules/dash-components-archetype/config/webpack/webpack.config.demo.js",
     "extract-metadata": "mkdirp lib && react-docgen --pretty -o lib/metadata.json src/components && node -e \"const fs = require('fs'); const path = require('path'); const m = JSON.parse(fs.readFileSync('./lib/metadata.json')); const r = {}; Object.keys(m).forEach(k => r[k.split(path.sep).join('/')] = m[k]); fs.writeFileSync('./lib/metadata.json', JSON.stringify(r, '\t', 2));\"",
-    "generate-python-classes": "python -c 'import dash; dash.development.component_loader.generate_classes()'",
     "lint": "eslint --fix --ignore-path .gitignore .",
     "test-frontend": "karma start node_modules/dash-components-archetype/config/karma/karma.conf.js",
     "test-frontend-cov": "karma start node_modules/dash-components-archetype/config/karma/karma.conf.coverage.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash-components-archetype",
-  "version": "0.2.11",
+  "version": "0.3.0",
   "description": "A [Builder](https://github.com/FormidableLabs/builder) Archetype for Dash components suites",
   "main": "index.js",
   "dependencies": {
@@ -28,13 +28,14 @@
   },
   "scripts": {
     "builder:check": "eslint --fix --ignore-path .gitignore --ext *.js config init",
-    "build-dev": "builder run clean-lib && builder run extract-metadata && webpack -w --config=node_modules/dash-components-archetype/config/webpack/webpack.config.dev.js",
+    "build-dev": "builder run clean-lib && builder run extract-metadata && builder run generate-python-classes && webpack -w --config=node_modules/dash-components-archetype/config/webpack/webpack.config.dev.js",
     "build-dev-lib": "webpack -w --config=node_modules/dash-components-archetype/config/webpack/webpack.config.dev.js",
-    "build-dist": "builder run clean-lib && builder run extract-metadata && webpack --config=node_modules/dash-components-archetype/config/webpack/webpack.config.dist.js",
+    "build-dist": "builder run clean-lib && builder run extract-metadata && builder run generate-python-classes && webpack --config=node_modules/dash-components-archetype/config/webpack/webpack.config.dist.js",
     "check": "builder run lint && builder run test-frontend-cov",
     "clean-lib": "mkdirp lib && rimraf lib/*",
     "demo": "webpack-dev-server --hot --inline --port=9000 --content-base demo --config=node_modules/dash-components-archetype/config/webpack/webpack.config.demo.js",
     "extract-metadata": "mkdirp lib && react-docgen --pretty -o lib/metadata.json src/components && node -e \"const fs = require('fs'); const path = require('path'); const m = JSON.parse(fs.readFileSync('./lib/metadata.json')); const r = {}; Object.keys(m).forEach(k => r[k.split(path.sep).join('/')] = m[k]); fs.writeFileSync('./lib/metadata.json', JSON.stringify(r, '\t', 2));\"",
+    "generate-python-classes": "python -c 'import dash; dash.development.component_loader.generate_classes()'",
     "lint": "eslint --fix --ignore-path .gitignore .",
     "test-frontend": "karma start node_modules/dash-components-archetype/config/karma/karma.conf.js",
     "test-frontend-cov": "karma start node_modules/dash-components-archetype/config/karma/karma.conf.coverage.js",


### PR DESCRIPTION
Solves (https://github.com/plotly/dash/issues/150), see (https://github.com/plotly/dash/pull/271)
Changes version to 0.3.0 in `package.json`, `CHANGELOG.md`, `dev/package.json`
##### In `init/{{packageNameUnderscored}}/__init__.py`
* Populate `_components` by importing classes from corresponding python files in output of `dash.development.component_loader.generate_classes` rather than building them with `dash.development.component_loader.load_components`.

##### In `package.json`
* Add a `generate-python-classes` build step which calls `python -c 'import dash; dash.development.component_loader.generate_classes()'`
* Call `generate-python-classes` after each `extract-metadata`